### PR TITLE
GTI client not able to find certs/ folder

### DIFF
--- a/ipython/add_nc_and_rep_services.py
+++ b/ipython/add_nc_and_rep_services.py
@@ -174,9 +174,9 @@ def main():
         lda_bu += 'dns_scores_bu.csv'
         lda_temp += 'dns_scores_temp.csv'
 
-    gti_command = ('pushd /{0}/refclient && '.format(userDir) + 'rest_client_path + ' -s '+ gti_server 
+    gti_command = ('pushd /{0}/refclient && '.format(userDir) + rest_client_path + ' -s '+ gti_server 
                   + ' -q \'{"ci":{"cliid":"87d8d1082c2f2f821f438b2359b7a5b4", "prn":"Duxbury", "sdkv":"1.0", "pv":"1.0.0", "pev":1, "rid":1, "affid":"0"},"q":[{"op":"ip","ip":"###IP###"}]}\''
-                  + ' -i '+ gti_user + ' -p \'' + gti_password + '\' -t && popd')`
+                  + ' -i '+ gti_user + ' -p \'' + gti_password + '\' -t && popd')
 
     ip_ranges = []
 

--- a/ipython/add_nc_and_rep_services.py
+++ b/ipython/add_nc_and_rep_services.py
@@ -174,9 +174,9 @@ def main():
         lda_bu += 'dns_scores_bu.csv'
         lda_temp += 'dns_scores_temp.csv'
 
-    gti_command = ('pushd /{0}/refclient && '.format(userDir) + rest_client_path + ' -s '+ gti_server 
+    gti_command = (rest_client_path + ' -s '+ gti_server 
                   + ' -q \'{"ci":{"cliid":"87d8d1082c2f2f821f438b2359b7a5b4", "prn":"Duxbury", "sdkv":"1.0", "pv":"1.0.0", "pev":1, "rid":1, "affid":"0"},"q":[{"op":"ip","ip":"###IP###"}]}\''
-                  + ' -i '+ gti_user + ' -p \'' + gti_password + '\' -t && popd')
+                  + ' -i '+ gti_user + ' -p \'' + gti_password + '\' -t')
 
     ip_ranges = []
 


### PR DESCRIPTION
Removing pushd and popd as it was causing No Jason Found error. 
The fix for the certificated not found is to create a symlink to ./certs folder in ~/ipython poiting to /home/_user_/refclient/certs.

Fixes   #51 
https://github.com/Open-Network-Insight/open-network-insight/issues/51
