### PR TITLE
PR: Adding scroll bar to timeline frame

### DIFF
--- a/ipython/storyboard_sconnect.html
+++ b/ipython/storyboard_sconnect.html
@@ -263,7 +263,7 @@
                         <!--<header class="intel-header-section intel-border-pale-blue" style="margin-bottom:0;">
                             <span class="intel-header-section-title">Timeline</span>
                         </header>-->
-                        <iframe name="timeView" id="timeView" target="timeView" class="time" src="timeline.html" scrolling="no"></iframe>
+                        <iframe name="timeView" id="timeView" target="timeView" class="time" src="timeline.html"></iframe>
                     </div>
                 </div>
             </div>

--- a/ipython/timeline.html
+++ b/ipython/timeline.html
@@ -138,7 +138,7 @@
                 "shortMonths": ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
             });
 
-            var width = $("#container").width();
+            var width = $("#container").width()-5; // 5 is the magic number to avoid having horizontal scroll bar
 
 
             var graph = d3.chart.eventDrops()


### PR DESCRIPTION
This fixes issue https://github.com/Open-Network-Insight/open-network-insight/issues/54

Allow iframe to have scroll bars, and don't use full frame's width to avoid horizontal scroll bar
