### PR TITLE
Network View: Set better values for force graph

### DIFF
--- a/ipython/sconnects_netflow.html
+++ b/ipython/sconnects_netflow.html
@@ -344,12 +344,12 @@
 
             // Graph force
             var force = d3.layout.force()
-                          .charge(-Math.round(h * 0.55)) // 0.55 is a magic number for graph styling purposes charge is 55% of the grap height
-                          .linkDistance(Math.round(h * 0.081)) // 0.081 is a magic number for graph styling purposes linkDistance is 8.1% of the graph height
-                          .gravity(.1)
-                          .size(size)
-                          .nodes(nodes)
-                          .links(edges);
+                        .linkDistance(70)
+                        .charge(-120)
+                        .chargeDistance(-Math.round(h * 0.55)) // 0.55 is a magic number for graph styling purposes charge is 55% of the grap height
+                        .size(size)
+                        .nodes(nodes)
+                        .links(edges);
 
             // Group and append the edges to the main SVG
             svg.append('g')


### PR DESCRIPTION
Tries to fix https://github.com/Open-Network-Insight/open-network-insight/issues/52

There is no good way to prevent nodes to reach the outer edge. The parameters for the force graph have been updated to provide better visualization.
