### PR TITLE
Modified run_oa.sh to include DNS and Flow execution

### DIFF
--- a/ipython/run_oa.sh
+++ b/ipython/run_oa.sh
@@ -1,17 +1,24 @@
 #!/bin/bash
 
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
 LIM=3000
 ndate=$1
+TYPE=$3
 
 source /etc/duxbay.conf
 export DBNAME
-export DSOURCES
+#export DSOURCES
 export LUSER
-export LIM
+#export LIM
 
 echo "executing ops for date: $ndate"
-echo `python2.7 lda_ranking.py --date $ndate --user ${LUSER} --ifile ${DSOURCES}_results.csv --ofile ${DSOURCES}_scores.csv --limit ${LIM}`
-echo `python2.7 add_nc_and_rep_services.py --date $ndate --user ${LUSER} --${DSOURCES}`
-echo `python2.7 suspicious_connects_op.py --date $ndate --user ${LUSER}`
 
-
+if [[ "$TYPE" == flow ]]; then
+    echo `python2.7 lda_ranking.py --date $ndate --user ${LUSER} --ifile ${TYPE}_results.csv --ofile ${TYPE}_scores.csv --limit ${LIM}`
+    echo `python2.7 add_nc_and_rep_services.py --date $ndate --user ${LUSER} --${TYPE}`
+    echo `python2.7 suspicious_connects_op.py --date $ndate --user ${LUSER}` elif [[ "$TYPE" == dns ]]; then
+    cd $dir/dns
+    echo `python2.7 $dir/dns/dns_oa.py -d $ndate -i $dir/dns -l ${LIM}` else
+    echo "data type not selected"
+fi


### PR DESCRIPTION
Modified run_oa.sh to receive 3 parameters:
data= the date that is going to be executed
limit=limit of results
type=flow or dns

This way we can run dns or flow OA process from a single script.

_code by_ @natedogs911 
