### PR TITLE
Adding validation to remove double space

### DIFF
--- a/ipython/dns/dns_suspicious_dendrogram.py
+++ b/ipython/dns/dns_suspicious_dendrogram.py
@@ -28,6 +28,7 @@ def main():
 
             # get data to query
             date=row[0].split(" ")
+            date = filter(None,date)
             if len(date) == 5:
                 year=date[2]
                 month=datetime.datetime.strptime(date[0], '%b').strftime('%m')
@@ -37,13 +38,13 @@ def main():
 
 def get_dendro(dbase,ip_dst,year,month,day,storage_path,impala_node):
 
-    if not os.path.isfile("{0}dendro-{1}.csv".format(storage_path,ip_dst)):        
-        
-        dndro_qry = ("SELECT dns_a, dns_qry_name, ip_dst FROM (SELECT susp.ip_dst, susp.dns_qry_name, susp.dns_a FROM {0}.dns as susp WHERE susp.y={1} AND susp.m={2} AND susp.d={3}  AND susp.ip_dst=\"{4}\" ) AS tmp GROUP BY dns_a, dns_qry_name, ip_dst").format(dbase,year,month,day,ip_dst)           
-    
+    if not os.path.isfile("{0}dendro-{1}.csv".format(storage_path,ip_dst)):
+
+        dndro_qry = ("SELECT dns_a, dns_qry_name, ip_dst FROM (SELECT susp.ip_dst, susp.dns_qry_name, susp.dns_a FROM {0}.dns as susp WHERE susp.y={1} AND susp.m={2} AND susp.d={3}  AND susp.ip_dst=\"{4}\" ) AS tmp GROUP BY dns_a, dns_qry_name, ip_dst").format(dbase,year,month,day,ip_dst)
+
         dendro_file = "{0}dendro-{1}.csv".format(storage_path,ip_dst)
         impala_cmd = "impala-shell -i {0} --print_header -B --output_delimiter=',' -q '{1}' -o {2}".format(impala_node,dndro_qry,dendro_file)
-        
+
         print impala_cmd
         subprocess.call(impala_cmd,shell=True)
 

--- a/ipython/dns/dns_suspicious_details.py
+++ b/ipython/dns/dns_suspicious_details.py
@@ -14,7 +14,7 @@ iana_config_file = "{0}/iana/iana_config.json".format(script_path)
 def main():
 
     print sys.argv
-    
+
     # get parameters.
     dns_scores = sys.argv[1]
     dbase = sys.argv[2]
@@ -28,6 +28,7 @@ def main():
 
             # get data to query
             date=row[0].split(" ")
+            date = filter(None,date)
             if len(date) == 5:
                 year=date[2]
                 month=datetime.datetime.strptime(date[0], '%b').strftime('%m')
@@ -43,9 +44,9 @@ def get_details(dbase,dns_qry_name,year,month,day,storage_path,hh,impala_node):
     edge_tmp  ="{0}edge-{1}_{2}_00.tmp".format(storage_path,dns_qry_name.replace("/","-"),hh)
 
     if not os.path.isfile(edge_file):
-        
-        dns_details_qry = ("SELECT frame_time,frame_len,ip_dst,ip_src,dns_qry_name,dns_qry_class,dns_qry_type,dns_qry_rcode,dns_a FROM {0}.dns WHERE y={1} AND m={2} AND d={3} AND dns_qry_name LIKE \"%{4}%\" AND h={6} LIMIT {5};").format(dbase,year,month,day,dns_qry_name,limit,hh)        
-        
+
+        dns_details_qry = ("SELECT frame_time,frame_len,ip_dst,ip_src,dns_qry_name,dns_qry_class,dns_qry_type,dns_qry_rcode,dns_a FROM {0}.dns WHERE y={1} AND m={2} AND d={3} AND dns_qry_name LIKE \"%{4}%\" AND h={6} LIMIT {5};").format(dbase,year,month,day,dns_qry_name,limit,hh)
+
         impala_cmd = "impala-shell -i {0} --print_header -B --output_delimiter=',' -q '{1}' -o {2}".format(impala_node,dns_details_qry,edge_tmp)
         print impala_cmd
         subprocess.call(impala_cmd,shell=True)


### PR DESCRIPTION
This code change fixes the problem with dns time stamp in dns_scores files, when the day of the connection < 10 tshark adds an extra space between Month and Day that is affecting the queries to the details.

@natedogs911 @rabarona @LedaLima @daortizh 
