### PR TITLE
GTI fix for DNS OA

### DIFF
--- a/ipython/dns/dns_oa.py
+++ b/ipython/dns/dns_oa.py
@@ -14,6 +14,7 @@ iana_config_file = "{0}/iana/iana_config.json".format(script_path)
 nc_config_file = "{0}/nc/nc_config.json".format(script_path)
 rep_services = []
 
+
 def main():
     query_ip_dict = {}
     limit = 0
@@ -21,11 +22,11 @@ def main():
 
     info("DNS OA starts...")
     try:
-        opts, args = getopt.getopt(sys.argv[1:], 'hd:i:l:',["help","date=", "ipython=","limit="])
+        opts, args = getopt.getopt(sys.argv[1:], 'hd:i:l:', ["help", "date=", "ipython=", "limit="])
     except getopt.GetoptError as err:
         print usage
         sys.exit(2)
-    for opt,arg in opts:
+    for opt, arg in opts:
         if opt in ("-h", "-help"):
             print usage
             sys.exit()
@@ -34,15 +35,15 @@ def main():
             if len(date) != 8:
                 error("Wrong date format, please verify. Excepected format is YYYYMMDD")
                 sys.exit()
-        elif opt in ("-i","-ipython"):
-           dns_ipython_location = arg
-	elif opt in ("-l", "-limit"):
-	    limit = arg
+        elif opt in ("-i", "-ipython"):
+            dns_ipython_location = arg
+        elif opt in ("-l", "-limit"):
+            limit = arg
 
     if limit == 0:
-	error("You need to pass a value for limit")
-	print usage
-	sys.exit()
+        error("You need to pass a value for limit")
+        print usage
+        sys.exit()
 
     y = date[:4]
     m = date[4:6]
@@ -51,113 +52,124 @@ def main():
     dns_results_file_path = "../user/{0}/dns_results.csv".format(date)
     updated_data = []
     info("Creating ipython notebooks and execution date folder")
-    create_ipython_notebooks(date,dns_ipython_location)
+    create_ipython_notebooks(date, dns_ipython_location)
 
     if not os.path.isfile(dns_results_file_path):
-        error("dns_results.csv file not found at ipython/user/{0}, please make sure the file exists and try again".format(date))
+        error(
+            "dns_results.csv file not found at ipython/user/{0}, please make sure the file exists and try again".format(
+                date))
         sys.exit()
     else:
-	with open(dns_results_file_path, 'rb') as dns_results_file:
+        with open(dns_results_file_path, 'rb') as dns_results_file:
 
-	    cur = [row.rstrip("\r\n").split(",") for row in dns_results_file]
-	    if len(cur) == 0 or len(cur) == 1:
-                info("There is no data in file dns_results.csv for the date and hour provided, please try a different one.")
+            cur = [row.rstrip("\r\n").split(",") for row in dns_results_file]
+            if len(cur) == 0 or len(cur) == 1:
+                info(
+                    "There is no data in file dns_results.csv for the date and hour provided, please try a different one.")
                 info("DNS OA completed but no data was found.")
                 sys.exit(1)
 
-            if (int(limit)+1) >= len(cur):
+            if (int(limit) + 1) >= len(cur):
                 cur = cur[1:]
             else:
-                cur = cur[1:int(limit)+1]
+                cur = cur[1:int(limit) + 1]
 
-	    if os.path.isfile(gti_config_file):
-		gti_config = json.load(open(gti_config_file))
-		init_rep_services(gti_config)
+            if os.path.isfile(gti_config_file):
+                gti_config = json.load(open(gti_config_file))
+                init_rep_services(gti_config)
 
-		indexes = gti_config["target_columns"]
-		cols = []
-		rep_services_results = []
-		for index in indexes:
-		    cols += extract_column(cur,index)
-		query_ip_dict = dict([(x,{}) for x in set(cols)])
-		info("Getting reputation for each service in config")
-		rep_services_results = [rep_service.check(None, query_ip_dict.keys()) for rep_service in rep_services]
-		all_rep_results = merge_rep_results(rep_services_results)
-		for val in query_ip_dict:
-		    try:
-			query_ip_dict[val]['rep'] = all_rep_results[val]
-		    except:
-			query_ip_dict[val]['rep'] = "UNKNOWN"
-	    else:
-		info("gti_config.json not present, will send data without reputation information")
+                indexes = gti_config["target_columns"]
+                cols = []
+                rep_services_results = []
+                for index in indexes:
+                    cols += extract_column(cur, index)
+                query_ip_dict = dict([(x, {}) for x in set(cols)])
+                info("Getting reputation for each service in config")
+                rep_services_results = [rep_service.check(None, query_ip_dict.keys()) for rep_service in rep_services]
+                all_rep_results = merge_rep_results(rep_services_results)
+                for val in query_ip_dict:
+                    try:
+                        query_ip_dict[val]['rep'] = all_rep_results[val]
+                    except:
+                        query_ip_dict[val]['rep'] = "UNKNOWN"
+            else:
+                info("gti_config.json not present, will send data without reputation information")
 
-	    info("Adding reputation column to dns_ml data")
-	    updated_data = [append_rep_column(query_ip_dict,row) for row in cur]
-	info("Transforming data removing unix_tstamp column")
-	updated_data = [remove_unix_tstamp_column(row) for row in updated_data]
-	info("Adding HH (hour) column to new data")
-	updated_data = [append_hh_column(row) for row in updated_data]
-	info("Adding severety columns")
-	updated_data = [append_sev_columns(row) for row in updated_data]
-	info("Adding iana labels")
-	if os.path.isfile(iana_config_file):
-	    iana_config = json.load(open(iana_config_file))
-	    iana = iana_transform.IanaTransform(iana_config["IANA"])
-	    updated_data = [add_iana_translation(row,iana) for row in updated_data]
-	else:
-	    updated_data = [row[:-1] + ["","",""] + [row[-1]] for row in updated_data]
-	info("Adding network context")
-	if os.path.isfile(nc_config_file):
-	    nc_config = json.load(open(nc_config_file))
-	    nc = network_context.NetworkContext(nc_config["NC"])
-	    updated_data = [row[:-1] + [nc.get_nc(row[2])] + [row[-1]]  for row in updated_data]
-	else:
-	    updated_data = [row[:-1] + [""] + [row[-1]] for row in updated_data]
-	info("Saving data to local csv")
-	save_to_csv_file(updated_data, date)
-    	info("Creating dns scores backup")
-    	create_dns_backup(date)
-	info("Calculating DNS OA details")
-	create_dns_details(date)
-	info("DNS OA successfully completed")
+            info("Adding reputation column to dns_ml data")
+            updated_data = [append_rep_column(query_ip_dict, row) for row in cur]
+        info("Transforming data removing unix_tstamp column")
+        updated_data = [remove_unix_tstamp_column(row) for row in updated_data]
+        info("Adding HH (hour) column to new data")
+        updated_data = [append_hh_column(row) for row in updated_data]
+        info("Adding severety columns")
+        updated_data = [append_sev_columns(row) for row in updated_data]
+        info("Adding iana labels")
+        if os.path.isfile(iana_config_file):
+            iana_config = json.load(open(iana_config_file))
+            iana = iana_transform.IanaTransform(iana_config["IANA"])
+            updated_data = [add_iana_translation(row, iana) for row in updated_data]
+        else:
+            updated_data = [row[:-1] + ["", "", ""] + [row[-1]] for row in updated_data]
+        info("Adding network context")
+        if os.path.isfile(nc_config_file):
+            nc_config = json.load(open(nc_config_file))
+            nc = network_context.NetworkContext(nc_config["NC"])
+            updated_data = [row[:-1] + [nc.get_nc(row[2])] + [row[-1]] for row in updated_data]
+        else:
+            updated_data = [row[:-1] + [""] + [row[-1]] for row in updated_data]
+        info("Saving data to local csv")
+        save_to_csv_file(updated_data, date)
+        info("Creating dns scores backup")
+        create_dns_backup(date)
+        info("Calculating DNS OA details")
+        create_dns_details(date)
+        info("DNS OA successfully completed")
+
 
 def create_dns_backup(date):
-    src = "{0}/user/{1}/dns_scores.csv".format(script_path,date)
-    dst = "{0}/user/{1}/dns_scores_bu.csv".format(script_path,date)
-    shutil.copy(src,dst)
+    src = "{0}/user/{1}/dns_scores.csv".format(script_path, date)
+    dst = "{0}/user/{1}/dns_scores_bu.csv".format(script_path, date)
+    shutil.copy(src, dst)
+
 
 def save_to_csv_file(data, date):
-    csv_file_location = "{0}/user/{1}/dns_scores.csv".format(script_path,date)
-    header = ["frame_time","frame_len","ip_dst","dns_qry_name","dns_qry_class","dns_qry_type","dns_qry_rcode",
-    "domain","subdomain","subdomain_length","num_periods","subdomain_entropy","top_domain","word",
-    "score","query_rep","hh","ip_sev","dns_sev","dns_qry_class_name","dns_qry_type_name","dns_qry_rcode_name","network_context","unix_tstamp"]
-    data.insert(0,header)
+    csv_file_location = "{0}/user/{1}/dns_scores.csv".format(script_path, date)
+    header = ["frame_time", "frame_len", "ip_dst", "dns_qry_name", "dns_qry_class", "dns_qry_type", "dns_qry_rcode",
+              "domain", "subdomain", "subdomain_length", "num_periods", "subdomain_entropy", "top_domain", "word",
+              "score", "query_rep", "hh", "ip_sev", "dns_sev", "dns_qry_class_name", "dns_qry_type_name",
+              "dns_qry_rcode_name", "network_context", "unix_tstamp"]
+    data.insert(0, header)
     with open(csv_file_location, 'w+') as dns_scores_file:
-	writer = csv.writer(dns_scores_file)
-	writer.writerows(data)
+        writer = csv.writer(dns_scores_file)
+        writer.writerows(data)
+
 
 def move_dns_results(dns_results_file_path, date):
     origin = dns_results_file_path
-    destination = "{0}/user/{1}/".format(script_path,date)
+    destination = "{0}/user/{1}/".format(script_path, date)
     subprocess.check_output("mv {0} {1}".format(origin, destination))
     subprocess.check_output("rm {0}".format(origin))
 
-def extract_column(cur,index):
-    return list(map(None,*cur)[index])
+
+def extract_column(cur, index):
+    return list(map(None, *cur)[index])
+
 
 def init_rep_services(gti_config):
     for service in gti_config:
-	if service != "target_columns":
-	    config = gti_config[service]
-	    module = __import__("gti.{0}.reputation".format(service),fromlist=['Reputation'])
-	    rep_services.append(module.Reputation(config))
+        if service != "target_columns":
+            config = gti_config[service]
+            module = __import__("gti.{0}.reputation".format(service), fromlist=['Reputation'])
+            rep_services.append(module.Reputation(config))
 
-def append_rep_column(query_ip_dict,row):
+
+def append_rep_column(query_ip_dict, row):
     column = ""
-    if row[3] in query_ip_dict:
-        column = query_ip_dict[row[3]]['rep']
+    if row[4] in query_ip_dict:
+        column = query_ip_dict[row[4]]['rep']
     row.append(column)
     return row
+
 
 def append_hh_column(row):
     date_time = row[0].split(" ")
@@ -168,6 +180,7 @@ def append_hh_column(row):
     row = temp_row + [row[-1]]
     return row
 
+
 def append_sev_columns(row):
     temp_row = row[:-1]
     temp_row.append(0)
@@ -175,22 +188,21 @@ def append_sev_columns(row):
     row = temp_row + [row[-1]]
     return row
 
+
 def add_iana_translation(row, iana):
     qry_class = row[4]
     qry_type = row[5]
     qry_rcode = row[6]
-    COL_RCODE = 'dns_qry_rcode'
-    COL_TYPE = 'dns_qry_type'
-    COL_CLASS = 'dns_qry_class'
-    qry_class_name = ""
-    qry_type_name = ""
-    qry_rcode_name = ""
-    qry_class_name = iana.get_name(qry_class, COL_CLASS)
-    qry_type_name = iana.get_name(qry_type, COL_TYPE)
-    qry_rcode_name = iana.get_name(qry_rcode, COL_RCODE)
+    col_rcode = 'dns_qry_rcode'
+    col_type = 'dns_qry_type'
+    col_class = 'dns_qry_class'
+    qry_class_name = iana.get_name(qry_class, col_class)
+    qry_type_name = iana.get_name(qry_type, col_type)
+    qry_rcode_name = iana.get_name(qry_rcode, col_rcode)
     temp_row = row[:-1]
     row = temp_row + [qry_class_name, qry_type_name, qry_rcode_name] + [row[-1]]
     return row
+
 
 def remove_unix_tstamp_column(row):
     unixtstamp = row[1]
@@ -198,22 +210,25 @@ def remove_unix_tstamp_column(row):
     row = row + [unixtstamp]
     return row
 
+
 def merge_rep_results(ds):
     z = {}
     for d in ds:
-	z = {k : "{0}::{1}".format(z.get(k,""),d.get(k,"")).strip('::') for k in set(z) | set(d) }
+        z = {k: "{0}::{1}".format(z.get(k, ""), d.get(k, "")).strip('::') for k in set(z) | set(d)}
     return z
 
-def create_ipython_notebooks(date,dns_ipython_location):
+
+def create_ipython_notebooks(date, dns_ipython_location):
     ipython_notebooks_script = "{0}/set_ipython_notebooks.sh".format(script_path)
-    command = "{0} {1} {2}".format(ipython_notebooks_script,dns_ipython_location,date)
+    command = "{0} {1} {2}".format(ipython_notebooks_script, dns_ipython_location, date)
     subprocess.check_output(command, shell=True)
 
+
 def create_dns_details(date):
-    dns_scores = "{0}/user/{1}/dns_scores.csv".format(script_path,date)
+    dns_scores = "{0}/user/{1}/dns_scores.csv".format(script_path, date)
     destination = "{0}/user/{1}/".format(script_path, date)
     dns_details_cmd = "python dns_oa_details_dendro.py {0} {1}".format(dns_scores, destination)
-    subprocess.call(dns_details_cmd,shell=True)
+    subprocess.call(dns_details_cmd, shell=True)
+
 
 main()
-

--- a/ipython/dns/gti/fb/reputation.py
+++ b/ipython/dns/gti/fb/reputation.py
@@ -2,103 +2,105 @@ import json
 import urllib2
 import urllib
 
+
+def _get_reputation_label(reputation):
+    if reputation == 'UNKNOWN':
+        return "fb:UNKNOWN:-1"
+    elif reputation == 'NON_MALICIOUS':
+        return "fb:NON_MALICIOUS:0"
+    elif reputation == 'SUSPICIOUS':
+        return "fb:SUSPICIOUS:2"
+    elif reputation == 'MALICIOUS':
+        return "fb:MALICIOUS:3"
+
+
 class Reputation(object):
-    
-    def __init__(self,conf):
-	self.initialize_members(conf)
-    
-    def initialize_members(self,conf):
-	self._fb_app_id = conf['app_id']
-	self._fb_app_secret = conf['app_secret']
+    def __init__(self, conf):
+        self._fb_app_id = conf['app_id']
+        self._fb_app_secret = conf['app_secret']
 
-    def check(self,ips=None, urls=None):
-	print "Threat-Exchange reputation check starts..."	
-	reputation_dict = {}
-	data = []
-	
-	if ips is not None:
-	    values = ips
-	    qtype = 'IP_ADDRESS'
-	    getopt = 'GET_IP_'
-	elif urls is not None: 
-	    values = urls
-	    qtype = 'DOMAIN'
-	    getopt = 'GET_NAME_'
-	else:
-	    print "Need either an ip or an url to check reputation."
-	    return reputation_dict
+    def check(self, ips=None, urls=None):
+        print "Threat-Exchange reputation check starts..."
+        reputation_dict = {}
+        data = []
 
-	for val in values:
-	    query_params = urllib.urlencode({
-		'type' : qtype,
-		'text' : val
-	    })
+        if ips is not None:
+            values = ips
+            qtype = 'IP_ADDRESS'
+            getopt = 'GET_IP_'
+        elif urls is not None:
+            values = urls
+            qtype = 'DOMAIN'
+            getopt = 'GET_NAME_'
+        else:
+            print "Need either an ip or an url to check reputation."
+            return reputation_dict
 
-	    indicator_request = {	
-		'method' : 'GET',
-		'name' : "{0}{1}".format(getopt,val.replace('.','_')),
-		'relative_url' : "/v2.4/threat_indicators?{0}".format(query_params)
-	    }
-	    
-	    descriptor_request = {
-		'method' : 'GET',
-		'relative_url' : '/v2.4/{result='+getopt+val.replace('.','_')+':$.data.*.id}/descriptors'
-	    }
-	
-	    data.append(indicator_request)
-	    data.append(descriptor_request)
-	    	    
-	    reputation_dict.update(self._request_reputation(data,val))
-	    data = []
+        for val in values:
+            query_params = urllib.urlencode({
+                'type': qtype,
+                'text': val
+            })
 
-	if len(data) > 0:
-	    reputation_dict.update(self._request_reputation(data))
-	
-	return reputation_dict
+            indicator_request = {
+                'method': 'GET',
+                'name': "{0}{1}".format(getopt, val.replace('.', '_')),
+                'relative_url': "/v2.4/threat_indicators?{0}".format(query_params)
+            }
 
-    def _request_reputation(self,data,name):
-	reputation_dict = {}
-	token = "{0}|{1}".format(self._fb_app_id, self._fb_app_secret)
-	request_body = {
-	    'access_token' : token,
-	    'batch' : data
-	}
-	request_body = urllib.urlencode(request_body)
-	
-	url = "https://graph.facebook.com/"
-	content_type = {'Content-Type': 'application/json'}
-	request = urllib2.Request(url,request_body,content_type)
-	str_response = urllib2.urlopen(request).read()
-	response = json.loads(str_response)
-	
-	for row in response:
-	    if row is None:
-		continue
-	    
-	    if row['code'] != 200:
-		reputation_dict[name] = self._get_reputation_label('UNKNOWN')
-		return reputation_dict
-	
-	    if 'body' in row:
-	        row_response = json.loads(row['body'])
-		if 'data' in row_response:
-		    #print row_response['data']	    
-		    row_response_data = row_response['data']
-		    name = row_response_data[0]['indicator']['indicator']
-	    	    reputation_dict[name] = self._get_reputation_label(row_response_data[0]['status'])
-		else: 
-		    reputation_dict[name] = self._get_reputation_label('UNKNOWN')
-	    else:
-		reputation_dict[name] = self._get_reputation_label('UNKNOWN')
-	
-	return reputation_dict
+            descriptor_request = {
+                'method': 'GET',
+                'relative_url': '/v2.4/{result=' + getopt + val.replace('.', '_') + ':$.data.*.id}/descriptors'
+            }
 
-    def _get_reputation_label(self,reputation):
-	if reputation == 'UNKNOWN':
-	    return "fb:UNKNOWN:-1"
-	elif reputation == 'NON_MALICIOUS':
-	    return "fb:NON_MALICIOUS:0"
-	elif reputation == 'SUSPICIOUS':
-	    return "fb:SUSPICIOUS:2"
-	elif reputation == 'MALICIOUS':
-	    return "fb:MALICIOUS:3"
+            data.append(indicator_request)
+            data.append(descriptor_request)
+
+            reputation_dict.update(self._request_reputation(data, val))
+            data = []
+
+        if len(data) > 0:
+            reputation_dict.update(self._request_reputation(data))
+
+        return reputation_dict
+
+    def _request_reputation(self, data, name):
+        reputation_dict = {}
+        token = "{0}|{1}".format(self._fb_app_id, self._fb_app_secret)
+        request_body = {
+            'access_token': token,
+            'batch': data
+        }
+        request_body = urllib.urlencode(request_body)
+
+        url = "https://graph.facebook.com/"
+        content_type = {'Content-Type': 'application/json'}
+        request = urllib2.Request(url, request_body, content_type)
+        try:
+            str_response = urllib2.urlopen(request).read()
+            response = json.loads(str_response)
+        except urllib2.HTTPError as e:
+            print "Error calling ThreatExchange in module fb: " + e.message
+            reputation_dict[name] = _get_reputation_label('UNKNOWN')
+            return reputation_dict
+
+        for row in response:
+            if row is None:
+                continue
+
+            if row['code'] != 200:
+                reputation_dict[name] = _get_reputation_label('UNKNOWN')
+                return reputation_dict
+
+            if 'body' in row:
+                row_response = json.loads(row['body'])
+                if 'data' in row_response:
+                    row_response_data = row_response['data']
+                    name = row_response_data[0]['indicator']['indicator']
+                    reputation_dict[name] = _get_reputation_label(row_response_data[0]['status'])
+                else:
+                    reputation_dict[name] = _get_reputation_label('UNKNOWN')
+            else:
+                reputation_dict[name] = _get_reputation_label('UNKNOWN')
+
+        return reputation_dict

--- a/ipython/dns/gti/gti/reputation.py
+++ b/ipython/dns/gti/gti/reputation.py
@@ -1,44 +1,52 @@
 import json
-from subprocess import check_output
+from subprocess import check_output, CalledProcessError
+
+
+def _get_reputation_label(reputation):
+    if reputation < 15:
+        return "gti:Minimal:1"
+    elif 15 <= reputation < 30:
+        return "gti:Unverified:-1"
+    elif 30 <= reputation < 50:
+        return "gti:Medium:2"
+    elif reputation >= 50:
+        return "gti:High:3"
+
 
 class Reputation(object):
-    
-    BATCH_SIZE = 10
+    BATCH_SIZE = 5
     REP_KEY = 'rep'
     AFLAG_KEY = 'aflag'
     DEFAULT_REP = 16
     QUERY_PLACEHOLDER = "###QUERY###"
-    
-    def __init__(self,conf):
-	self.initialize_members(conf)
 
-    def initialize_members(self,conf):
-	self._gti_server = conf['server']
-	self._gti_user = conf['user']
-	self._gti_password = conf['password']
-	self._gti_ci = conf['ci']
-	self._gti_rest_client_path = conf['refclient']
+    def __init__(self, conf):
+        self._gti_rest_client_path = conf['refclient']
+        self._gti_ci = conf['ci']
+        self._gti_password = conf['password']
+        self._gti_user = conf['user']
+        self._gti_server = conf['server']
 
-    def check(self,ips=None, urls=None):
-	print "GTI reputation check starts..."
-	reputation_dict = {}
-	op = ""
-	command = "{0} -s {1} -q \'{2}\' -i {3} -p \'{4}\' -t".format(self._gti_rest_client_path, self._gti_server, self._gti_ci, self._gti_user, self._gti_password)
-	if ips is not None:
-	    values = ips
-	    op = "ip"
-	elif urls is not None:
-	    values = urls
-	    op = "url"
-	else:
-	    print "Need either an ip or an url to check reputation."
-	    return reputation_dict
-	
-	i = 0
+    def check(self, ips=None, urls=None):
+        print "GTI reputation check starts..."
+        reputation_dict = {}
+        command = "{0} -s {1} -q \'{2}\' -i {3} -p \'{4}\' -t".format(self._gti_rest_client_path, self._gti_server,
+                                                                      self._gti_ci, self._gti_user, self._gti_password)
+        if ips is not None:
+            values = ips
+            op = "ip"
+        elif urls is not None:
+            values = urls
+            op = "url"
+        else:
+            print "Need either an ip or an url to check reputation."
+            return reputation_dict
+
+        i = 0
         queries = []
         responses = []
-	for val in values:
-	    queries.append("{\"op\":\"" + op + "\", \""+ op +"\":\""+ val +"\"}")
+        for val in values:
+            queries.append("{\"op\":\"" + op + "\", \"" + op + "\":\"" + val + "\"}")
             i += 1
             if i == self.BATCH_SIZE:
                 cmd_temp = command
@@ -47,7 +55,6 @@ class Reputation(object):
                 responses += self._call_gti(command, self.BATCH_SIZE)
                 command = cmd_temp
                 i = 0
-                query = ""
                 queries = []
 
         if len(queries) > 0:
@@ -58,11 +65,11 @@ class Reputation(object):
         ip_counter = 0
         for query_resp in responses:
             if self.AFLAG_KEY in query_resp or self.REP_KEY not in query_resp:
-                reputation_dict[values[ip_counter]] = self._get_reputation_label(self.DEFAULT_REP)
+                reputation_dict[values[ip_counter]] = _get_reputation_label(self.DEFAULT_REP)
             else:
-		reputation = query_resp[self.REP_KEY]
+                reputation = query_resp[self.REP_KEY]
                 reputation = int(reputation)
-                reputation_dict[values[ip_counter]] = self._get_reputation_label(reputation)
+                reputation_dict[values[ip_counter]] = _get_reputation_label(reputation)
             ip_counter += 1
         return reputation_dict
 
@@ -72,17 +79,11 @@ class Reputation(object):
             result_dict = json.loads(response_json[0:len(response_json) - 1])
             responses = result_dict['a']
             return responses
-        except:
+        except CalledProcessError as e:
+            print "Error calling McAfee GTI client in gti module: " + e.output
             error_resp = [{self.REP_KEY: self.DEFAULT_REP}] * num_values
-            return  error_resp
-
-    def _get_reputation_label(self,reputation):
-	if reputation < 15:
-	    return "gti:Minimal:1"
-	elif reputation >= 15 and reputation < 30:
-	    return "gti:Unverified:-1"
-	elif reputation >= 30 and reputation < 50:
-	    return "gti:Medium:2"
-	elif reputation >= 50:
-	    return "gti:High:3"	    
-	
+            return error_resp
+        except ValueError as e:
+            print "Error reading JSON response in gti module: " + e.message
+            error_resp = [{self.REP_KEY: self.DEFAULT_REP}] * num_values
+            return error_resp

--- a/ipython/dns/gti/gti_config.json
+++ b/ipython/dns/gti/gti_config.json
@@ -1,5 +1,5 @@
 {
-    "target_columns":[3],
+    "target_columns":[4],
     "gti":{
             "server" : "<server>",
             "user" : "<user>",


### PR DESCRIPTION
Aims to fix https://github.com/Open-Network-Insight/open-network-insight/issues/75
- Changed configuration: DNS OA was trying to check reputation for IP instead of URL. Modified configuration file to point to column 4.
- Modified dns_oa.py: dns_oa.py was trying to map the index in configuration with the results of GTI reputation check, needed to change 3 to 4 as well.
- Modified GTI McAfee call to send 5 requests instead of 10: after doing more test, we found that McAfee will return error message with 10 queries, 5 is working.
- Modified GTI Facebook to return UNKNOWN if response is 400 Bad Request. This is happening when URL contains characters that ThreatExchange is not able to process.
- Spaces and Tabs added by IDE.
