### PR TITLE
Removed unused reference to the .config file from all Edge notebooks

### DIFF
--- a/oa/dns/ipynb_templates/Edge_Investigation_master.ipynb
+++ b/oa/dns/ipynb_templates/Edge_Investigation_master.ipynb
@@ -26,10 +26,6 @@
     "dsource = path[len(path)-2]  \n",
     "dpath = '/'.join(['data' if var == 'ipynb' else var for var in path]) + '/'\n",
     "\n",
-    "with open('/etc/duxbay.conf') as conf:\n",
-    "    for line in conf.readlines():\n",
-    "        if \"LUSER\" in line: LUSER = line.split(\"=\")[1].strip('\\n').replace(\"'\",\"\");  break\n",
-    "\n",
     "sconnect = dpath + 'dns_scores.csv'\n",
     "sconnectbu = dpath + 'dns_scores_bu.csv'\n",
     "score_tmp = dpath + 'score_tmp.csv'  "
@@ -267,7 +263,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "version": "2.7.5"
   }
  },
  "nbformat": 4,

--- a/oa/flow/ipynb_templates/Edge_Investigation_master.ipynb
+++ b/oa/flow/ipynb_templates/Edge_Investigation_master.ipynb
@@ -30,10 +30,6 @@
     "\n",
     "from IPython.display import display, Javascript, clear_output\n",
     "\n",
-    "with open('/etc/duxbay.conf') as conf:\n",
-    "    for line in conf.readlines():\n",
-    "        if \"LUSER=\" in line: LUSER = line.split(\"=\")[1].strip('\\n').replace(\"'\",\"\");  break \n",
-    "             \n",
     "path = os.getcwd().split(\"/\") \n",
     "t_date = path[len(path)-1]   \n",
     "dsource = path[len(path)-2]  \n",
@@ -230,7 +226,7 @@
     "        print \"Suspicious connects successfully updated\"        \n",
     "        display(Javascript('window.parent.iframeReloadHook && window.parent.iframeReloadHook();'))\n",
     "        # Close widgets form\n",
-    "        searches.close()\n",
+    "        bigBox.close()\n",
     "        # Rebuild widgets form\n",
     "        displaythis()\n",
     "        ml_feedback()\n",
@@ -398,7 +394,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "version": "2.7.5"
   }
  },
  "nbformat": 4,

--- a/oa/proxy/ipynb_templates/Edge_Investigation_master.ipynb
+++ b/oa/proxy/ipynb_templates/Edge_Investigation_master.ipynb
@@ -26,10 +26,6 @@
     "dsource = path[len(path)-2]  \n",
     "dpath = '/'.join(['data' if var == 'ipynb' else var for var in path]) + '/'\n",
     "\n",
-    "with open('/etc/duxbay.conf') as conf:\n",
-    "    for line in conf.readlines():\n",
-    "        if \"LUSER\" in line: LUSER = line.split(\"=\")[1].strip('\\n').replace(\"'\",\"\");  break\n",
-    "\n",
     "sconnect = dpath + 'proxy_scores.csv'\n",
     "sconnectbu = dpath + 'proxy_scores_bu.csv'\n",
     "score_tmp = dpath + 'proxy_tmp.csv'  "
@@ -221,7 +217,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "version": "2.7.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
For flows, the widget container name changed from "searches" to "bigBox" to avoid a "not found" error after clicking the Save button 
