### PR TITLE
Proxy OA now expects tab separated results file from ML

### DIFF
--- a/oa/dns/dns_oa.py
+++ b/oa/dns/dns_oa.py
@@ -38,6 +38,7 @@ class OA(object):
         self._ingest_summary_path = None
         self._dns_scores = []
         self._dns_scores_headers = []
+        self._results_delimiter = '\t'
 
         # get app configuration.
         self._oni_conf = Util.get_oni_conf()
@@ -110,7 +111,7 @@ class OA(object):
 
             # read number of results based in the limit specified.
             self._logger.info("Reading {0} dns results file: {1}".format(self._date,dns_results))
-            self._dns_results = Util.read_results(dns_results,self._limit)[:]        
+            self._dns_results = Util.read_results(dns_results,self._limit,self._results_delimiter)[:]
             if len(self._dns_results) == 0: self._logger.error("There are not flow results.");sys.exit(1)
 
         else:

--- a/oa/flow/flow_oa.py
+++ b/oa/flow/flow_oa.py
@@ -39,6 +39,7 @@ class OA(object):
         self._ipynb_path = None
         self._ingest_summary_path = None
         self._flow_scores = []
+        self._results_delimiter = '\t'
 
         # get app configuration.
         self._oni_conf = Util.get_oni_conf()  
@@ -108,7 +109,7 @@ class OA(object):
 
             # read number of results based in the limit specified.
             self._logger.info("Reading {0} flow results file: {1}".format(self._date,flow_results))
-            self._flow_results = Util.read_results(flow_results,self._limit)          
+            self._flow_results = Util.read_results(flow_results,self._limit,self._results_delimiter)
             if len(self._flow_results) == 0: self._logger.error("There are not flow results.");sys.exit(1)
 
         else:
@@ -123,7 +124,7 @@ class OA(object):
         ldaba_index = self._conf["flow_results_fields"]["lda_score_ba"]
 
         # filter results add sev and rank.
-        self._logger.info("Filtering required columns based on configuration")       
+        self._logger.info("Filtering required columns based on configuration")
         self._flow_scores.extend([ [0] +  [ conn[i] for i in self._conf['column_indexes_filter'] ] + [(conn[ldaab_index] if (conn[ldaab_index]<= conn[ldaba_index]) else conn[ldaba_index])] + [n]  for n, conn in enumerate(self._flow_results) ])
      
     def _create_flow_scores_csv(self):

--- a/oa/proxy/proxy_oa.py
+++ b/oa/proxy/proxy_oa.py
@@ -40,6 +40,7 @@ class OA(object):
         self._proxy_scores = []
         self._proxy_scores_headers = []
         self._proxy_extra_columns = []
+        self._results_delimiter = '\t'
 
         # get app configuration.
         self._oni_conf = Util.get_oni_conf()
@@ -115,7 +116,7 @@ class OA(object):
 
             # read number of results based in the limit specified.
             self._logger.info("Reading {0} proxy results file: {1}".format(self._date,proxy_results))
-            self._proxy_results = Util.read_results(proxy_results,self._limit)[:]        
+            self._proxy_results = Util.read_results(proxy_results,self._limit,self._results_delimiter)[:]        
             if len(self._proxy_results) == 0: self._logger.error("There are not proxy results.");sys.exit(1)
         else:
             self._logger.error("There was an error getting ML results from HDFS")
@@ -176,7 +177,6 @@ class OA(object):
                 rep_results = {k: "{0}::{1}".format(rep_results.get(k, ""), result.get(k, "")).strip('::') for k in set(rep_results) | set(result)}
 
             self._proxy_scores = [ conn + [ rep_results[conn[key]] ]   for conn in self._proxy_scores  ]
-
         
     def _add_severity(self):
         # Add severity column

--- a/oa/utils.py
+++ b/oa/utils.py
@@ -71,12 +71,12 @@ class Util(object):
 		return get_results_cmd
 
 	@classmethod
-	def read_results(cls,file,limit):
+	def read_results(cls,file,limit, delimiter=','):
 		
 		# read csv results.
 		result_rows = []
 		with open(file, 'rb') as results_file:
-			csv_reader = csv.reader(results_file)
+			csv_reader = csv.reader(results_file, delimiter = delimiter)
 			for i in range(0, int(limit)):
 				try:
 					row = csv_reader.next()


### PR DESCRIPTION
The _read_results_ function now receives a parameter to select the delimiter, this is set by default as comma. Proxy_oa now expects the results file from ML to be tab separated
